### PR TITLE
add dataplane update flow for updating k8s version

### DIFF
--- a/cli/commands/update.go
+++ b/cli/commands/update.go
@@ -1,0 +1,37 @@
+package commands
+
+import (
+	"bz/pkg/dataplanes"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	updateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "bz update - create entites [dataplane] in baaz control plane",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			switch args[0] {
+			case "dataplane", "dataplanes":
+				if dataplane_name == "" {
+					return fmt.Errorf("dataplane name cannot be empty")
+				}
+				resp, err := dataplanes.UpdateDataplane(file, dataplane_name)
+				if err != nil {
+					return err
+				}
+				fmt.Println(resp)
+			default:
+				return NotValidArgs(commonValidArgs)
+			}
+			return nil
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+	updateCmd.Flags().StringVarP(&file, "file", "f", "", ".yaml file speficifying entity to be created")
+	updateCmd.Flags().StringVarP(&dataplane_name, "dataplane", "", "", "dataplane name")
+}

--- a/internal/khota_handler/khota_msg.go
+++ b/internal/khota_handler/khota_msg.go
@@ -36,6 +36,8 @@ const (
 	DataplaneAddedSuccess                 CustomMsg = "Dataplane added success"
 	DataplaneRemoveSuccess                CustomMsg = "Dataplane remove success"
 	DataplanePatchFail                    CustomMsg = "Dataplane patch fail"
+	DataplaneUpdateSuccess                CustomMsg = "Dataplane updated successfully"
+	DataplaneUpdateFail                   CustomMsg = "Dataplane update fail"
 )
 
 // Tenant

--- a/internal/khota_handler/routes.go
+++ b/internal/khota_handler/routes.go
@@ -102,6 +102,12 @@ var routes = Routes{
 		CreateDataPlane,
 	},
 	Route{
+		"UPDATE DATA PLANE",
+		"PUT",
+		"/api/v1/dataplane/{dataplane_name}",
+		UpdateDataPlane,
+	},
+	Route{
 		"ADD DATA PLANE",
 		"PUT",
 		"/api/v1/dataplane/{dataplane_name}/customer/{customer_name}",

--- a/internal/khota_handler/utils.go
+++ b/internal/khota_handler/utils.go
@@ -75,7 +75,6 @@ func makeDataPlaneName(cloudType v1.CloudType, customerName, region string) stri
 		return string(cloudType) + "-" + region + "-" + String(4)
 	}
 	return customerName + "-" + string(cloudType) + "-" + region + "-" + String(4)
-
 }
 
 func makeTenantName(appName, appSize string) string {


### PR DESCRIPTION
Added a new cli update command for updating the dataplane k8s version as dataplane name is generated randomly, so we need to pass the dataplane name in the update command.
example:
bz update dataplane -f ../examples/shared_infra/dataplane-shared.yaml --dataplane=aws-us-east-1-bcwf
